### PR TITLE
Change behavior of -f flag to follow the file (closes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ USAGE:
 
 OPTIONS:
     -t, --timezone <TIMEZONE>    Sets the timezone in which output should be printed. (Default: local timezone)
-    -f, --format <FORMAT>        Custom format for parsing dates. (Default: autodetected patterns)
+    -f, --follow                 Follow the file indefinitely as changes are added. (Default: Off)
+        --format <FORMAT>        Custom format for parsing dates. (Default: autodetected patterns)
     -h, --help                   Prints help information
     -V, --version                Prints version information
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,11 +15,25 @@ use std::io;
 use std::io::{BufRead, BufReader};
 use std::process;
 
-fn run(filename: Option<&str>, tz: Option<&str>, fmt: Option<&str>) -> Result<bool, String> {
+struct AppArgs<'a> {
+    filename: Option<&'a str>,
+    custom_format: Option<&'a str>,
+    timezone: Option<&'a str>,
+    should_follow: bool,
+}
+
+fn run(args: AppArgs) -> Result<bool, String> {
+    let AppArgs {
+        filename,
+        custom_format: fmt,
+        timezone: tz,
+        should_follow: follow
+    } = args;
+
     let c = Converter::new(tz, fmt)?;
     let stdin = io::stdin();
 
-    let reader: Box<dyn BufRead> = match filename {
+    let mut reader: Box<dyn BufRead> = match filename {
         Some(name) => {
             let file = File::open(name).expect("Error opening file");
             Box::new(BufReader::new(file))
@@ -27,17 +41,34 @@ fn run(filename: Option<&str>, tz: Option<&str>, fmt: Option<&str>) -> Result<bo
         None => Box::new(stdin.lock()),
     };
 
-    for line in reader.lines() {
-        match line {
-            Ok(content) => println!("{}", c.convert(&content)),
-            Err(err) => {
-                eprintln!("{}: {}", "Exited while reading lines", err.description());
-                return Err(format!("Exited while reading lines: {}", err));
+    if follow {
+        let mut buf = String::new();
+
+        loop {
+            match reader.read_line(&mut buf) {
+                Ok(bytes) if bytes > 0 => {
+                    println!("{}", c.convert(&buf.trim_end()));
+                    buf.clear();
+                },
+                Ok(_) => (),
+                Err(err) => return handle_err(err)
+            }
+        }
+    } else {
+        for line in reader.lines() {
+            match line {
+                Ok(content) => println!("{}", c.convert(&content)),
+                Err(err) => return handle_err(err)
             }
         }
     }
 
     return Ok(true);
+}
+
+fn handle_err(err: std::io::Error) -> Result<bool, String> {
+    eprintln!("{}: {}", "Exited while reading lines", err.description());
+    return Err(format!("Exited while reading lines: {}", err));
 }
 
 fn main() {
@@ -58,21 +89,31 @@ fn main() {
                 .takes_value(true)
                 .help("Sets the timezone in which output should be printed. (Default: local timezone)"),
         ).arg(
+            Arg::with_name("follow")
+                .long("follow")
+                .short("f")
+                .value_name("FOLLOW")
+                .required(false)
+                .takes_value(false)
+                .help("Follow the file indefinitely as changes are added. (Default: Off)"),
+        ).arg(
             Arg::with_name("format")
                 .long("format")
-                .short("f")
                 .value_name("FORMAT")
                 .required(false)
                 .takes_value(true)
-                .help("Custom format for parsing dates. (Default: autodetected patterns)"),
+                .help("Custom format for parsing dates. (Default: autodetected patterns)")
         );
 
     let matches = app.get_matches();
-    let timezone = matches.value_of("timezone");
-    let custom_format = matches.value_of("format");
-    let filename = matches.value_of("FILE");
+    let args = AppArgs {
+        filename: matches.value_of("FILE"),
+        custom_format: matches.value_of("format"),
+        timezone: matches.value_of("timezone"),
+        should_follow: matches.is_present("follow")
+    };
 
-    let result = run(filename, timezone, custom_format);
+    let result = run(args);
 
     match result {
         Err(error) => {


### PR DESCRIPTION
Hi 👋🏽,

I'm new to Rust so please scrutinize this PR. I'm trying to get my feet wet here. This should close #12.

### Summary of Changes
- Added file "follow", mapped to `-f` or `--follow`
- The `-f` shorthand flag has been removed from `format`.  **This is a breaking change!**
- `run` accepts the struct `AppArgs` since I thought the fn args were getting a bit long

### Questions
- How does one test this? Is there a good way to do integration tests with command line programs in Rust?
- Do you disagree with the `run` arg refactor?
- Is too much happening in `main.rs`? Should `run` be factored out into a separate file?
- Should backwards compatibility be preserved? Or is this project early enough where we don't care?